### PR TITLE
Remove redundant composer drupal-scaffold call

### DIFF
--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -27,14 +27,6 @@ composer-install:
         - require:
             - install-composer
 
-composer-drupal-scaffold:
-    cmd.run:
-        - name: composer drupal-scaffold
-        - cwd: /srv/journal-cms
-        - user: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - composer-install
-
 site-settings:
     file.managed:
         - name: /srv/journal-cms/config/local.settings.php
@@ -43,7 +35,7 @@ site-settings:
         - user: {{ pillar.elife.deploy_user.username }}
         - group: {{ pillar.elife.deploy_user.username }}
         - require:
-            - composer-drupal-scaffold
+            - composer-install
         - require_in:
             - site-install
             


### PR DESCRIPTION
I have figured out how to trigger the `drupal-scaffold` after `composer install`.

See: https://github.com/elifesciences/elife-2.0-website/commit/614505a34a5fbb12922fe99bba27f6ee45a05092