### PR TITLE
Adding .aws/credentials files for cli and nginx usage

### DIFF
--- a/salt/journal-cms/config/home-user-.aws-credentials
+++ b/salt/journal-cms/config/home-user-.aws-credentials
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id = {{ pillar.journal_cms.aws.access_key_id }}
+aws_secret_access_key = {{ pillar.journal_cms.aws.secret_access_key }}
+region = {{ pillar.journal_cms.aws.region }}

--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -138,6 +138,28 @@ site-install:
         # always execute for now
         #- unless:  ../vendor/bin/drush cget system.site name
 
+aws-credentials-cli:
+    file.managed:
+        - name: /home/{{ pillar.elife.deploy_user.username }}/.aws/credentials
+        - source: salt://journal-cms/config/home-user-.aws-credentials
+        - user: {{ pillar.elife.deploy_user.username }}
+        - group: {{ pillar.elife.deploy_user.username }}
+        - makedirs: True
+        - template: jinja
+        - require:
+            - site-install
+
+aws-credentials-www-data:
+    file.managed:
+        - name: /var/www/.aws/credentials
+        - source: salt://journal-cms/config/home-user-.aws-credentials
+        - user: www-data
+        - group: www-data
+        - makedirs: True
+        - template: jinja
+        - require:
+            - site-install
+
 # populates data into the labs and subjects until they will be created through the user interface
 migrate-content:
     cmd.run:

--- a/salt/pillar/journal-cms.sls
+++ b/salt/pillar/journal-cms.sls
@@ -8,3 +8,8 @@ journal_cms:
         name: legacy_cms
         user: legacy_cms
         password: legacy_cms
+
+    aws:
+        access_key_id: null
+        secret_access_key: null
+        region: us-east-1


### PR DESCRIPTION
@jamiehollern this adds the credentials to both the CLI user (that we use for crons or long-running processes) and to the Nginx user. With these files you should be able to use the PHP AWS SDK without specifying credentials in the code.