### PR TITLE
Remove auth_published credentials

### DIFF
--- a/salt/journal-cms/config/srv-journal-config-local.settings.php
+++ b/salt/journal-cms/config/srv-journal-config-local.settings.php
@@ -42,8 +42,3 @@ $settings['jcms_article_auth_unpublished'] = '{{ pillar.journal_cms.api.auth_unp
 {% else %}
 $settings['jcms_article_auth_unpublished'] = null;
 {% endif %}
-{% if pillar.journal_cms.api.auth_published %}
-$settings['jcms_article_auth_published'] = '{{ pillar.journal_cms.api.auth_published }}';
-{% else %}
-$settings['jcms_article_auth_published'] = null;
-{% endif %}

--- a/salt/pillar/journal-cms.sls
+++ b/salt/pillar/journal-cms.sls
@@ -21,7 +21,6 @@ journal_cms:
         articles_endpoint: null
         all_articles_endpoint: null
         auth_unpublished: null
-        auth_published: null
 
 api_dummy:
     standalone: False


### PR DESCRIPTION
It seems journal-cms is not using this anymore, as the unpublished
credentials cover everything is needed:
```
[09:54:18][giorgio@Newton:~/code/journal-cms]$ grep -r auth_unpublished src/
src/modules/jcms_article/src/FetchArticle.php:        'Authorization' =>
Settings::get('jcms_article_auth_unpublished'),
src/modules/jcms_article/src/FetchArticle.php:          'Authorization'
=> Settings::get('jcms_article_auth_unpublished'),
src/modules/jcms_article/src/FetchArticleVersions.php:
'Authorization' => Settings::get('jcms_article_auth_unpublished'),
[09:54:20][giorgio@Newton:~/code/journal-cms]$ grep -r auth_published src/
[09:54:30][giorgio@Newton:~/code/journal-cms]$
```