### PR TITLE
Looking for a solution: serving files

### DIFF
--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -61,6 +61,7 @@ web-sites-file-permissions:
             chmod -f 777 web/sites/default/files/css || true
             chmod -f 777 web/sites/default/files/js || true
             chmod -f 777 web/sites/default/files/styles || true
+            chmod -Rf 777 web/sites/default/files || true
         - cwd: /srv/journal-cms
         - require:
             - journal-cms-repository


### PR DESCRIPTION
This is not a fix, we'll do something better.

Essentially files are there owned by `elife:elife`, but there may be some which are created by `www-data`. The solution we use in other projects to let anyone read and write those is the sticky group bit (group being `www-data`) plus umask 0002.