### PR TITLE
Feat rds support

### DIFF
--- a/salt/journal-cms/config/srv-journal-config-local.settings.php
+++ b/salt/journal-cms/config/srv-journal-config-local.settings.php
@@ -2,7 +2,7 @@
 $databases = array();
 $databases['default']['default'] = array(
     'driver' => 'mysql',
-    'database' => '{{ salt['elife.cfg']('project.rds_dbname') or pillar.journal_cms.db.name }}',
+    'database' => '{{ pillar.journal_cms.db.name }}',
     'username' => '{{ pillar.journal_cms.db.user }}',
     'password' => '{{ pillar.journal_cms.db.password }}',
     'host' =>     '{{ salt['elife.cfg']('cfn.outputs.RDSHost') or 'localhost' }}',

--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -169,10 +169,10 @@ journal-cms-{{ key }}-user:
     mysql_user.present:
         - name: {{ db.user }}
         - password: {{ db.password }}
-        - host: localhost
 
         {% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
         # remote mysql
+        - host: '10.0.2.%' # todo, fix this
         - connection_user: {{ salt['elife.cfg']('project.rds_username') }} # rds 'owner' uname
         - connection_pass: {{ salt['elife.cfg']('project.rds_password') }} # rds 'owner' pass
         - connection_host: {{ salt['elife.cfg']('cfn.outputs.RDSHost') }}
@@ -180,6 +180,7 @@ journal-cms-{{ key }}-user:
         
         {% else %}
         # local mysql
+        - host: localhost
         - connection_pass: {{ pillar.elife.db_root.password }}
         
         {% endif %}
@@ -196,12 +197,14 @@ journal-cms-{{ key }}-access:
 
         {% if salt['elife.cfg']('cfn.outputs.RDSHost') %}
         # remote mysql
+        - host: '10.0.2.%' # todo, fix this
         - connection_user: {{ salt['elife.cfg']('project.rds_username') }} # rds 'owner' uname
         - connection_pass: {{ salt['elife.cfg']('project.rds_password') }} # rds 'owner' pass
         - connection_host: {{ salt['elife.cfg']('cfn.outputs.RDSHost') }}
         - connection_port: {{ salt['elife.cfg']('cfn.outputs.RDSPort') }}
 
         {% else %}
+        - host: localhost # default
         - connection_pass: {{ pillar.elife.db_root.password }}
         
         {% endif %}


### PR DESCRIPTION
I need to fix up the ip pattern, but this appears to work with rds.

rds doesn't like `elife.internal` domain names.

if this works I can create a pattern from the `subnet-cidr` in the project file 