### PR TITLE
Add setting for legacy cms images bucket

### DIFF
--- a/salt/journal-cms/config/srv-journal-config-local.settings.php
+++ b/salt/journal-cms/config/srv-journal-config-local.settings.php
@@ -59,3 +59,4 @@ $settings['jcms_article_auth_unpublished'] = '{{ pillar.journal_cms.api.auth_unp
 {% else %}
 $settings['jcms_article_auth_unpublished'] = null;
 {% endif %}
+$settings['jcms_migrate_legacy_cms_images_bucket'] = 'prod-elife-legacy-cms-images';


### PR DESCRIPTION
This setting is needed to access the public S3 bucket which contains some images to import while migrating legacy content.

See: https://github.com/elifesciences/journal-cms/pull/114