### PR TITLE
Optimize autoload

### DIFF
--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -96,7 +96,13 @@ journal-cms-repository:
 
 composer-install:
     cmd.run:
-        - name: composer --no-interaction install
+        {% if pillar.elife.env in ['prod', 'end2end', 'continuumtest'] %}
+        - name: composer --no-interaction install --optimize-autoloader --no-dev
+        {% elif pillar.elife.env != 'dev' %}
+        - name: composer --no-interaction install --optimize-autoloader
+        {% else %}
+        - name: composer --no-interaction install 
+        {% endif %}
         - cwd: /srv/journal-cms
         - user: {{ pillar.elife.deploy_user.username }}
         - env:

--- a/salt/pillar/journal-cms.sls
+++ b/salt/pillar/journal-cms.sls
@@ -48,3 +48,4 @@ journal_cms:
 
 api_dummy:
     standalone: False
+    pinned_revision_file: /srv/journal-cms/api-dummy.sha1


### PR DESCRIPTION
Sometimes /ping goes over 1 second response time due to overhead of
Composer autoloading. The class map is suspiciously small so this brings
its size in line with other PHP projects