### PR TITLE
Start from an empty db in dev and ci

### DIFF
--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -126,6 +126,17 @@ site-services:
 
 {% for key in ['db'] %}
 {% set db = pillar.journal_cms[key] %}
+
+{% if pillar.elife.env in ['dev', 'ci'] %}
+journal-cms-{{ key }}-reset:
+    mysql_database.absent:
+        - name: {{ db.name }}
+        # local mysql only, RDS not supported, don't mess with that
+        - connection_pass: {{ pillar.elife.db_root.password }}
+        - require_in:
+            - mysql_database: journal-cms-{{ key }}
+{% endif %}
+
 journal-cms-{{ key }}:
     mysql_database.present:
         - name: {{ db.name }}


### PR DESCRIPTION
When a pull request introduces a database migration, going back to the master version of the code may encounter problems on site-install due to the schema having been modified. Like for other applications, it's easier to start from an empty database; it shouldn't affect performance as we repeat site-install every time anyway