### PR TITLE
Always restart long-running processes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-elifeFormula('journal-cms', '/srv/journal-cms', null, ['s1604'])
+elifeFormula('journal-cms', '/srv/journal-cms')

--- a/salt/journal-cms/config/lib-systemd-system-journal-cms-article-import@.service
+++ b/salt/journal-cms/config/lib-systemd-system-journal-cms-article-import@.service
@@ -7,7 +7,7 @@ PartOf={{ process }}-controller.target
 WantedBy={{ process }}-controller.target
 
 [Service]
-Restart=on-failure
+Restart=always
 RestartSec=10
 TimeoutStopSec=70
 User={{ pillar.elife.deploy_user.username }}

--- a/salt/journal-cms/config/lib-systemd-system-journal-cms-send-notifications@.service
+++ b/salt/journal-cms/config/lib-systemd-system-journal-cms-send-notifications@.service
@@ -7,7 +7,7 @@ PartOf={{ process }}-controller.target
 WantedBy={{ process }}-controller.target
 
 [Service]
-Restart=on-failure
+Restart=always
 RestartSec=10
 TimeoutStopSec=70
 User={{ pillar.elife.deploy_user.username }}

--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -19,6 +19,7 @@ journal-cms-localhost:
 journal-cms-php-extensions:
     cmd.run:
         - name: |
+            set -e
             apt-get -y --no-install-recommends install php7.0-redis php7.0-igbinary php7.0-uploadprogress 
             {% if pillar.elife.env in ['ci'] %}
             apt-get -y install php7.0-sqlite3


### PR DESCRIPTION
Follow up to https://github.com/elifesciences/journal-cms-formula/pull/39/files after `end2end` broke.

They have some conditions (e.g. too much memory being used) where they will stop gracefully and expect to be restarted as a fresh process.