### PR TITLE
Feature: enabled multiservice states by default in example topfile

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -20,5 +20,5 @@ base:
         - elife.swapspace
         # not used in dev:
         #- journal-cms.cron
-        #- elife.multiservice
-        #- journal-cms.processes
+        - elife.multiservice
+        - journal-cms.processes


### PR DESCRIPTION
disabled originally because they would always be run, even if the environment was 14.04 (multiservice is 16.04+)