### PR TITLE
Clear cache after updatedb

### DIFF
--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -289,7 +289,9 @@ site-install:
 
 site-update-db:
     cmd.run:
-        - name: ../vendor/bin/drush updatedb -y
+        - name: |
+            ../vendor/bin/drush updatedb -y
+            ../vendor/bin/drush cr
         - cwd: /srv/journal-cms/web
         - user: {{ pillar.elife.deploy_user.username }}
         - require: 


### PR DESCRIPTION
This is needed for instances where new classes are introduced which undergo autoregistration. When they are referenced in configuration they will not have yet been discovered and will trigger an error such as:

```
$ ../vendor/bin/drush cim -y
 Collection  Config                                    Operation
             rest.resource.validate_content_rest_reso  create
             urce
Import the listed configuration changes? (y/n): y
Synchronized configuration: create                                   [ok]
rest.resource.validate_content_rest_resource.
Finalizing configuration synchronization.                            [ok]
The import failed due for the following reasons:                     [error]
Unexpected error during import with operation create for
rest.resource.validate_content_rest_resource:
&#039;rest_resource_config&#039; entity with ID
&#039;validate_content_rest_resource&#039; already exists.
```