### PR TITLE
mysql57.sls removal

### DIFF
--- a/salt/example.top
+++ b/salt/example.top
@@ -7,7 +7,8 @@ base:
         - elife.composer
         - elife.nginx
         - elife.nginx-php7
-        - elife.mysql57
+        - elife.mysql-client
+        - elife.mysql-server
         - elife.redis-server
         # these 2 used for testing AWS interactions locally
         - elife.docker


### PR DESCRIPTION
replaces references to mysql57 with mysql-client and mysql-server