### PR TITLE
api-dummy, adds call to smoke-tests when in dev mode

### DIFF
--- a/salt/journal-cms/api-dummy.sls
+++ b/salt/journal-cms/api-dummy.sls
@@ -4,7 +4,7 @@ api-dummy-nginx-vhost-dev:
         - source: salt://journal-cms/config/etc-nginx-sites-enabled-api-dummy-dev.conf
         - require:
             - api-dummy-composer-install
-        - listen_in:
+        - watch_in:
             - service: nginx-server-service
             - service: php-fpm
 

--- a/salt/journal-cms/api-dummy.sls
+++ b/salt/journal-cms/api-dummy.sls
@@ -7,3 +7,11 @@ api-dummy-nginx-vhost-dev:
         - listen_in:
             - service: nginx-server-service
             - service: php-fpm
+
+api-dummy-smoke-tests:
+    cmd.run:
+        - cwd: /srv/api-dummy
+        - runas: {{ pillar.elife.deploy_user.username }}
+        - name: ./smoke_tests.sh
+        - require:
+            - api-dummy-nginx-vhost-dev


### PR DESCRIPTION
fyi @nlisgo , this will run the smoke tests on any instance of journal-cms that is using the api-dummy for testing. It would have caught the problem we had with the api-dummy server running under the old php-fpm before.