### PR TITLE
Add article_fragments_endpoint setting

### DIFF
--- a/salt/journal-cms/config/srv-journal-config-local.settings.php
+++ b/salt/journal-cms/config/srv-journal-config-local.settings.php
@@ -93,6 +93,7 @@ $settings['jcms_articles_endpoint'] = '{{ pillar.journal_cms.api.articles_endpoi
 $settings['jcms_metrics_endpoint'] = '{{ pillar.journal_cms.api.metrics_endpoint }}';
 $settings['jcms_all_digests_endpoint'] = '{{ pillar.journal_cms.api.all_digests_endpoint }}';
 $settings['jcms_all_articles_endpoint'] = '{{ pillar.journal_cms.api.all_articles_endpoint }}';
+$settings['jcms_article_fragments_endpoint'] = '{{ pillar.journal_cms.api.article_fragments_endpoint }}';
 $settings['jcms_article_fragment_images_endpoint'] = '{{ pillar.journal_cms.api.article_fragment_images_endpoint }}';
 {% if pillar.journal_cms.api.auth_unpublished %}
 $settings['jcms_article_auth_unpublished'] = '{{ pillar.journal_cms.api.auth_unpublished }}';

--- a/salt/pillar/journal-cms.sls
+++ b/salt/pillar/journal-cms.sls
@@ -34,6 +34,7 @@ journal_cms:
         metrics_endpoint: {{ dummy_url }}/metrics/article/%s/%s
         all_articles_endpoint: {{ dummy_url }}/articles
         all_digests_endpoint: {{ dummy_url }}/digests
+        article_fragments_endpoint: null
         article_fragment_images_endpoint: null
         auth_unpublished: null
 


### PR DESCRIPTION
This is needed for: https://github.com/elifesciences/journal-cms/pull/679

This will need to merged in after: https://github.com/elifesciences/builder-configuration/pull/180

Both can be deployed at the same time. Once the Journal CMS PR is merged and deployed we can remove references to `article_fragment_images_endpoint` here and in `builder-configuration`.

