### PR TITLE
Remove reference to article_fragment_images_endpoint

### DIFF
--- a/salt/journal-cms/config/srv-journal-config-local.settings.php
+++ b/salt/journal-cms/config/srv-journal-config-local.settings.php
@@ -94,7 +94,6 @@ $settings['jcms_metrics_endpoint'] = '{{ pillar.journal_cms.api.metrics_endpoint
 $settings['jcms_all_digests_endpoint'] = '{{ pillar.journal_cms.api.all_digests_endpoint }}';
 $settings['jcms_all_articles_endpoint'] = '{{ pillar.journal_cms.api.all_articles_endpoint }}';
 $settings['jcms_article_fragments_endpoint'] = '{{ pillar.journal_cms.api.article_fragments_endpoint }}';
-$settings['jcms_article_fragment_images_endpoint'] = '{{ pillar.journal_cms.api.article_fragment_images_endpoint }}';
 {% if pillar.journal_cms.api.auth_unpublished %}
 $settings['jcms_article_auth_unpublished'] = '{{ pillar.journal_cms.api.auth_unpublished }}';
 {% else %}

--- a/salt/pillar/journal-cms.sls
+++ b/salt/pillar/journal-cms.sls
@@ -35,7 +35,6 @@ journal_cms:
         all_articles_endpoint: {{ dummy_url }}/articles
         all_digests_endpoint: {{ dummy_url }}/digests
         article_fragments_endpoint: null
-        article_fragment_images_endpoint: null
         auth_unpublished: null
 
     users:


### PR DESCRIPTION
This should be merged in before: https://github.com/elifesciences/builder-configuration/pull/181

This is related to: https://github.com/elifesciences/journal-cms/pull/680