### PR TITLE
Temporarily disable cron to purge revision tables

### DIFF
--- a/salt/journal-cms/cron.sls
+++ b/salt/journal-cms/cron.sls
@@ -15,12 +15,13 @@ journal-cms-cron-drupal:
         - require:
             - migrate-content
 
-journal-cms-cron-purge-revisions:
-    cron.present:
-        - identifier: journal-cms-cron-purge-revisions
-        - name: cd /srv/journal-cms/web && ../vendor/bin/drush paragraphs-revisions-purge --feedback=1000 && ../vendor/bin/drush paragraphs-revisions-optimise
-        - user: {{ pillar.elife.deploy_user.username }}
-        - hour: 3
-        - minute: 0
-        - require:
-            - migrate-content
+# nlisgo: 2024-02-14 temporarily disable until fix implemented.
+#journal-cms-cron-purge-revisions:
+#    cron.present:
+#        - identifier: journal-cms-cron-purge-revisions
+#        - name: cd /srv/journal-cms/web && ../vendor/bin/drush paragraphs-revisions-purge --feedback=1000 && ../vendor/bin/drush paragraphs-revisions-optimise
+#        - user: {{ pillar.elife.deploy_user.username }}
+#        - hour: 3
+#        - minute: 0
+#        - require:
+#            - migrate-content


### PR DESCRIPTION
Will reinstate when we fix the scripts and perform the first purge manually.