### PR TITLE
Modify site-install to excute on dev and ci environments, while exclu…

### DIFF
--- a/salt/journal-cms/init.sls
+++ b/salt/journal-cms/init.sls
@@ -297,22 +297,41 @@ site-was-installed-check:
             - cmd: site-install
 
 site-install:
-    cmd.run:
-        - name: |
-            set -e
-            ../vendor/bin/drush site-install minimal --existing-config -y
-            ####test -e /home/{{ pillar.elife.deploy_user.username }}/site-was-installed.flag && ../vendor/bin/drush cr || echo "site was not installed before, not rebuilding cache"
-            #../vendor/bin/drush cr # may fail with "You have requested a non-existent service "cache.backend.redis"
-            redis-cli flushall
-        - cwd: /srv/journal-cms/web
-        - runas: {{ pillar.elife.deploy_user.username }}
-        - require:
-            - journal-cms-repository
-        # always perform a new site-install on dev and ci
-        {% if pillar.elife.env not in ['dev', 'ci'] %}
-        - unless:
-            - sudo -u {{ pillar.elife.deploy_user.username}} ../vendor/bin/drush cget system.site name
-        {% endif %}
+  cmd.run:
+    - name: |
+        set -e
+        ../vendor/bin/drush site-install minimal --existing-config -y
+        ####test -e /home/{{ pillar.elife.deploy_user.username }}/site-was-installed.flag && ../vendor/bin/drush cr || echo "site was not installed before, not rebuilding cache"
+        #../vendor/bin/drush cr # may fail with "You have requested a non-existent service "cache.backend.redis"
+        redis-cli flushall
+    - cwd: /srv/journal-cms/web
+    - runas: {{ pillar.elife.deploy_user.username }}
+    - require:
+        - journal-cms-repository
+
+# Always perform a new site-install on dev and ci, never on continuumtest or prod
+{% if pillar.elife.env in ['continuumtest', 'prod'] %}
+site-install_skip:  # Define a new state to skip site-install on continuumtest and prod
+  cmd.run:
+    - name: echo "Never perform site-install on continuumtest and prod"
+{% elif pillar.elife.env in ['dev', 'ci'] %}
+site-install_dev_ci:  # Define a new state to perform site-install on dev and ci
+  cmd.run:
+    - name: |
+        set -e
+        ../vendor/bin/drush site-install minimal --existing-config -y
+        ####test -e /home/{{ pillar.elife.deploy_user.username }}/site-was-installed.flag && ../vendor/bin/drush cr || echo "site was not installed before, not rebuilding cache"
+        #../vendor/bin/drush cr # may fail with "You have requested a non-existent service "cache.backend.redis"
+        redis-cli flushall
+    - cwd: /srv/journal-cms/web
+    - runas: {{ pillar.elife.deploy_user.username }}
+    - require:
+        - journal-cms-repository
+{% else %}
+site-install_other:  # Define a new state to check site-install condition
+  cmd.run:
+    - name: sudo -u {{ pillar.elife.deploy_user.username }} ../vendor/bin/drush cget system.site name
+{% endif %}
 
 site-update-db:
     cmd.run:


### PR DESCRIPTION
@nlisgo I have break down the `site-install` snippet into a few conditional statements;

- If the environment (pillar.elife.env) is 'continuumtest' or 'prod', it defines a new state site-install_skip. This state simply echoes a message indicating that site-install is skipped for these environments.

- If the environment is 'dev' or 'ci', it defines a new state site-install_dev_ci that mirrors the original site-install state, ensuring installation occurs on these environments.

- If the environment is neither 'continuumtest', 'prod', 'dev', nor 'ci', it defines a new state site-install_other. This state performs a check (drush cget system.site name) to retrieve the site name using Drush.

I have tested it on Vagrant and it runs as expected, I have added `dev` to `site-install_skip` block on Vagrant and skipped the execution and echoed as expected:
```
 ID: site-install_skip
    Function: cmd.run
        Name: echo "Never perform site-install on continuumtest and prod"
      Result: True
     Comment: Command "echo "Never perform site-install on continuumtest and prod"" run
     Started: 14:03:43.006772
    Duration: 5.504 ms
     Changes:   

```
 Please let me know if require any adjustments